### PR TITLE
Made extracting initials from string with nameInitials() more accurate.

### DIFF
--- a/InitialsImageView.swift
+++ b/InitialsImageView.swift
@@ -113,10 +113,13 @@ extension UIImageView {
     }
 }
 
-private func initialsFromString(string: String) -> String { 
-    return string.components(separatedBy: .whitespacesAndNewlines).reduce("") { 
-        ($0.isEmpty ? "" : "\($0.uppercased().first!)") + ($1.isEmpty ? "" : "\($1.uppercased().first!)") 
-    }
+private func initialsFromString(string: String) -> String {
+    var nameComponents = string.uppercased().components(separatedBy: CharacterSet.letters.inverted)
+    nameComponents.removeAll(where: {$0.isEmpty})
+    
+    let firstInitial = nameComponents.first?.first
+    let lastInitial  = nameComponents.count > 1 ? nameComponents.last?.first : nil
+    return (firstInitial != nil ? "\(firstInitial!)" : "") + (lastInitial != nil ? "\(lastInitial!)" : "")
 }
 
 private func randomColorComponent() -> Int {


### PR DESCRIPTION
Previously if non letter characters, such as John (Doe), were in the string it would extract the incorrect initials.

Here are before and after tests:
Passed String: John
Old: J
New: J
Passed String: John Doe
Old: JD
New: JD
Passed String: *** John Doe ***
Old: **
New: JD
Passed String: John (Doe)
Old: J(
New: JD
Passed String: John Ron Long (Lucky) Doe
Old: JD
New: JD
Passed String: &*(#($)%))@*^^%$
Old: &
New: 
