### PR TITLE
Request 0.8.0 tag and bump Podspec to match

### DIFF
--- a/InitialsImageView.podspec
+++ b/InitialsImageView.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.author       = { "Tom Bachant" => "tom@dashride.com" }
   s.platform     = :ios, '8.0'
   s.source = { :git => "https://github.com/bachonk/InitialsImageView.git",
-               :tag => '0.7.0' }
+               :tag => '0.8.0' }
   s.source_files  = 'InitialsImageView.swift'
   s.requires_arc = true
   s.swift_version = '5.0'

--- a/InitialsImageViewSampleSwift/InitialsImageViewSampleSwift/Info.plist
+++ b/InitialsImageViewSampleSwift/InitialsImageViewSampleSwift/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.7.0</string>
+	<string>0.8.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
I forgot to do this in #19.  Currently, the latest tag on the repo is 0.7.0, which doesn't include the SPM manifest—so SPM doesn't actually work if you try to specify a version.

Even though there are no code changes, I'd like to request an 0.8.0 tag for SPM support—this single commit would bump the Podspec to match across the Pod and SPM.